### PR TITLE
[DC-8596] - Update library versions to fix vulnerabilities reported by Platform team

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .settings(
     scalaVersion := "3.3.4",
-    libraryDependencies              ++= AppDependencies.compile ++ AppDependencies.test
+    libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test
   )
   .settings(majorVersion := 2)
   .settings(ScoverageSettings())
@@ -12,8 +12,8 @@ lazy val microservice = Project(appName, file("."))
 Test / test := (Test / test)
   .dependsOn(scalafmtCheckAll)
   .value
-  scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all"))
+scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all"))
 scalacOptions ++= Seq(
-    "-Wconf:src=routes/.*:s",
-    "-Wconf:msg=Flag.*repeatedly:s"
+  "-Wconf:src=routes/.*:s",
+  "-Wconf:msg=Flag.*repeatedly:s"
 )

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,9 +1,9 @@
-import play.sbt.PlayImport._
-import sbt._
+import play.sbt.PlayImport.*
+import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.19.0"
+  val bootstrapVersion = "10.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
@@ -11,9 +11,6 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-test-play-30" % bootstrapVersion % Test,
-    "org.scalatest"          %% "scalatest"              % "3.2.17" % Test,
-    "org.scalatestplus.play" %% "scalatestplus-play"     % "7.0.1" % Test,
-    "org.scalatestplus"      %% "mockito-4-11"           % "3.2.18.0" % Test
+    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,10 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
-  Resolver.ivyStylePatterns)
+  Resolver.ivyStylePatterns
+)
 
-addSbtPlugin("uk.gov.hmrc"       %  "sbt-auto-build"        % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"       %  "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework" %  "sbt-plugin"            % "3.0.8")
-addSbtPlugin("org.scoverage"     %  "sbt-scoverage"         % "2.2.2")
-addSbtPlugin("org.scalameta"     %  "sbt-scalafmt"          % "2.5.2")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.10")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.2.2")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.2")


### PR DESCRIPTION
Description - Bootstrap and sbt-plugin version update to fix below vulnerabilities.

Below has been done as part of this PR

- upgrade bootstrap and play version to address below vulnerability
   
   Vulnerability IDs
   CVE-2025-66566
   CVE-2025-12183

- remove the redundant test dependencies as these are getting retrieved from hmrc bootstrap-play

- minor refactoring and formatting